### PR TITLE
enables support for a snap package and disables loop disks to show up in the disks page

### DIFF
--- a/data/io.github.nokse22.inspector.appdata.xml.in
+++ b/data/io.github.nokse22.inspector.appdata.xml.in
@@ -19,9 +19,9 @@ The app creates a GUI for commands like lsusb, lscpu, lspci, uname and more.</p>
   <url type="bugtracker">https://github.com/Nokse22/inspector/issues</url>
 
   <releases>
-  	<release version="0.1.0" date="2023-08-05">
+  	<release version="0.1.4" date="2023-08-07">
     		<description>
-			<p>First release</p>
+			<p>Latest release</p>
 		</description>
   	</release>
   </releases>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('inspector',
-          version: '0.1.0',
+          version: '0.1.4',
     meson_version: '>= 0.62.0',
   default_options: [ 'warning_level=2', 'werror=false', ],
 )

--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,7 @@ class CommandTestApplication(Adw.Application):
                                 developer_name='Nokse',
                                 issue_url='https://github.com/Nokse22/inspector/issues',
                                 website='https://github.com/Nokse22/inspector',
-                                version='0.1.0',
+                                version='0.1.4',
                                 developers=['Nokse'],
                                 copyright='© 2023 Nokse')
         about.present()

--- a/src/window.py
+++ b/src/window.py
@@ -98,10 +98,10 @@ class CommandTestWindow(Adw.PreferencesWindow):
 
     def execute_terminal_command(self, command):
         if 'SNAP' not in os.environ:
-            console_permissions = "flatpak-spawn --host"
+            console_permissions = "flatpak-spawn --host "
         else:
-            console_permissions = " "
-        txt = console_permissions + " " + command
+            console_permissions = ""
+        txt = console_permissions + command
         process = subprocess.Popen(txt, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE, shell=True)
         try:
@@ -223,14 +223,14 @@ class CommandTestWindow(Adw.PreferencesWindow):
                 if not fnmatch.fnmatch(device['name'], 'loop*'):
                     text = f"Name: {device['name']}, Size: {device['size']}"
                     group = Adw.PreferencesGroup(title=device['name'], description="command: lsblk")
-                refresh_button = Gtk.Button(icon_name="view-refresh-symbolic",valign=3, css_classes=["flat"])
-                refresh_button.connect("clicked", self.update_disk_page)
-                group.set_header_suffix(refresh_button)
-                self.disks_content.add(group)
-                self.disk_page_children.append(group)
-                row = Adw.ActionRow(title="Total size")
-                row.add_suffix(Gtk.Label(label=device['size'], wrap=True))
-                group.add(row)
+                    refresh_button = Gtk.Button(icon_name="view-refresh-symbolic",valign=3, css_classes=["flat"])
+                    refresh_button.connect("clicked", self.update_disk_page)
+                    group.set_header_suffix(refresh_button)
+                    self.disks_content.add(group)
+                    self.disk_page_children.append(group)
+                    row = Adw.ActionRow(title="Total size")
+                    row.add_suffix(Gtk.Label(label=device['size'], wrap=True))
+                    group.add(row)
                 if "children" in device:
                     group = Adw.PreferencesGroup()
                     self.disks_content.add(group)

--- a/src/window.py
+++ b/src/window.py
@@ -97,10 +97,10 @@ class CommandTestWindow(Adw.PreferencesWindow):
         self.update_system_page()
 
     def execute_terminal_command(self, command):
-    if 'SNAP' not in os.environ:
-        console_permissions = "flatpak-spawn --host"
-    else:
-        console_permissions = " "
+        if 'SNAP' not in os.environ:
+            console_permissions = "flatpak-spawn --host"
+        else:
+            console_permissions = " "
         txt = console_permissions + " " + command
         process = subprocess.Popen(txt, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE, shell=True)
@@ -217,7 +217,8 @@ class CommandTestWindow(Adw.PreferencesWindow):
         else:
             data = json.loads(out)
             for device in data["blockdevices"]:
-                text = f"Name: {device['name']}, Size: {device['size']}"
+                if 'loop' not in {device['name']}:
+                    text = f"Name: {device['name']}, Size: {device['size']}"
                 group = Adw.PreferencesGroup(title=device['name'], description="command: lsblk")
                 refresh_button = Gtk.Button(icon_name="view-refresh-symbolic",valign=3, css_classes=["flat"])
                 refresh_button.connect("clicked", self.update_disk_page)

--- a/src/window.py
+++ b/src/window.py
@@ -97,9 +97,10 @@ class CommandTestWindow(Adw.PreferencesWindow):
         self.update_system_page()
 
     def execute_terminal_command(self, command):
-        if 'SNAP' not in os.environ:
+    if 'SNAP' not in os.environ:
         console_permissions = "flatpak-spawn --host"
-
+    else:
+        console_permissions = " "
         txt = console_permissions + " " + command
         process = subprocess.Popen(txt, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE, shell=True)

--- a/src/window.py
+++ b/src/window.py
@@ -184,8 +184,11 @@ class CommandTestWindow(Adw.PreferencesWindow):
         group.set_header_suffix(refresh_button)
         self.system_content.add(group)
         self.system_page_children.append(group)
-
-        out = self.execute_terminal_command("cat /etc/os-release")
+        
+        if 'SNAP' in os.environ:
+            out = self.execute_terminal_command("cat /var/lib/snapd/hostfs/etc/os-release")
+        else:
+            out = self.execute_terminal_command("cat /etc/os-release")
         out = out.splitlines()
 
         for line in out:

--- a/src/window.py
+++ b/src/window.py
@@ -20,7 +20,7 @@
 from gi.repository import Adw
 from gi.repository import Gtk
 from gi.repository import Gio
-import gi, os, subprocess, threading, time, json, re
+import gi, os, subprocess, threading, time, json, re, fnmatch
 
 class CommandTestWindow(Adw.PreferencesWindow):
     __gtype_name__ = 'CommandTestWindow'
@@ -220,7 +220,7 @@ class CommandTestWindow(Adw.PreferencesWindow):
         else:
             data = json.loads(out)
             for device in data["blockdevices"]:
-                if 'loop' not in {device['name']}:
+                if not fnmatch.fnmatch(device['name'], 'loop*'):
                     text = f"Name: {device['name']}, Size: {device['size']}"
                 group = Adw.PreferencesGroup(title=device['name'], description="command: lsblk")
                 refresh_button = Gtk.Button(icon_name="view-refresh-symbolic",valign=3, css_classes=["flat"])

--- a/src/window.py
+++ b/src/window.py
@@ -222,7 +222,7 @@ class CommandTestWindow(Adw.PreferencesWindow):
             for device in data["blockdevices"]:
                 if not fnmatch.fnmatch(device['name'], 'loop*'):
                     text = f"Name: {device['name']}, Size: {device['size']}"
-                group = Adw.PreferencesGroup(title=device['name'], description="command: lsblk")
+                    group = Adw.PreferencesGroup(title=device['name'], description="command: lsblk")
                 refresh_button = Gtk.Button(icon_name="view-refresh-symbolic",valign=3, css_classes=["flat"])
                 refresh_button.connect("clicked", self.update_disk_page)
                 group.set_header_suffix(refresh_button)

--- a/src/window.py
+++ b/src/window.py
@@ -97,7 +97,9 @@ class CommandTestWindow(Adw.PreferencesWindow):
         self.update_system_page()
 
     def execute_terminal_command(self, command):
+        if 'SNAP' not in os.environ:
         console_permissions = "flatpak-spawn --host"
+
         txt = console_permissions + " " + command
         process = subprocess.Popen(txt, stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE, shell=True)
@@ -656,5 +658,3 @@ class CommandTestWindow(Adw.PreferencesWindow):
         #             row = Adw.ActionRow(title=key)
         #             row.add_suffix(Gtk.Label(label=value, xalign=1, wrap=True, hexpand=True))
         #             group2.add(row)
-        
-


### PR DESCRIPTION
This package reads a lot of sensitive details, which needs plugs `hardware-observe`, `network-observe`, `system-observe` etc. Now, if you wish, you can create an account in the snap store, and I'll help you in publishing the app in the store. Also, it'll need grant from the policy-reviewers to allow auto connect to the said plugs. So, it'll take some time. Would you like to have it? I have also updated the app version in places. Kindly check the code with flatpak once, as I was not able to do so, but I didn't messed any flatpak code, so, hope it'll be fine