### PR TITLE
keeping the dmi path same for snap

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -512,12 +512,8 @@ class CommandTestWindow(Adw.PreferencesWindow):
         for child in self.motherboard_page_children:
             self.motherboard_content.remove(child)
         self.motherboard_page_children = []
-
-        if 'SNAP' in os.environ:
-            dmi_path = "/var/lib/snapd/hostfs/sys/devices/virtual/dmi/id/"
-        else:
-            dmi_path = "/sys/devices/virtual/dmi/id/"
-
+        
+        dmi_path = "/sys/devices/virtual/dmi/id/"
         dmi_keys = [
             ("bios_date", "BIOS Date"),
             ("bios_release", "BIOS Release"),


### PR DESCRIPTION
The os-release was necessary to be changed for the base snap, because the core22 that powers all the snaps, have its separate os-release file, which is mounted in `/etc/release` rest things can be mostly kept same. This fixes the Motherboard part, but still I guess it needs another plug to give more details. Which I'll look into.