### PR TITLE
appdata: `translate=no` properties and developer ID

### DIFF
--- a/data/io.github.nokse22.inspector.appdata.xml.in
+++ b/data/io.github.nokse22.inspector.appdata.xml.in
@@ -13,6 +13,9 @@
 
   <content_rating type="oars-1.1" />
   <developer_name translate="no">Nokse</developer_name>
+  <developer id="io.github.nokse22">
+	  <name translate="no">Nokse</name>
+  </developer>
   <launchable type="desktop-id">io.github.nokse22.inspector.desktop</launchable>
   <translation type="gettext">inspector</translation>
 

--- a/data/io.github.nokse22.inspector.appdata.xml.in
+++ b/data/io.github.nokse22.inspector.appdata.xml.in
@@ -12,7 +12,7 @@
 	</description>
 
   <content_rating type="oars-1.1" />
-  <developer_name translatable="no">Nokse</developer_name>
+  <developer_name translate="no">Nokse</developer_name>
   <launchable type="desktop-id">io.github.nokse22.inspector.desktop</launchable>
   <translation type="gettext">inspector</translation>
 
@@ -24,14 +24,14 @@
 
   <releases>
     <release version="0.1.8" date="2023-09-26">
-    	<description translatable="no">
+    	<description translate="no">
 			  <p>Improved app design and usability</p>
     	  <p>Updated runtime to 45</p>
     	  <p>Added French translation</p>
 		  </description>
   	</release>
     <release version="0.1.7" date="2023-09-15">
-    	<description translatable="no">
+    	<description translate="no">
 			  <p>Fixed typo (kawaii-ghost)</p>
     	  <p>Improved metadata</p>
     	  <p>Made labels selectable</p>
@@ -41,18 +41,18 @@
 		  </description>
   	</release>
     <release version="0.1.6" date="2023-08-12">
-    	<description translatable="no">
+    	<description translate="no">
 				<p>Fixed a critical bug if the app was run with older versions of lsblk</p>
     	  <p>Made the app more stable</p>
 	    </description>
   	</release>
   	<release version="0.1.5" date="2023-08-11">
-    	<description translatable="no">
+    	<description translate="no">
 			  <p>Added motherboard/bios page</p>
 		  </description>
   	</release>
   	<release version="0.1.4" date="2023-08-07">
-    	<description translatable="no">
+    	<description translate="no">
 			  <p>Bug fixes</p>
 		  </description>
   	</release>


### PR DESCRIPTION
### appdata: `translate=no` properties

It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub require a developer tag and developer ID.

> A developer tag with a name child tag must be present. Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
<name>Developer name</name>
</developer>
```
Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

